### PR TITLE
edit update_batch_circuit_metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,7 @@ Version 16.1
 
 * Remove multiversion documentation. `#115 <https://github.com/iqm-finland/iqm-client/pull/115>`_
 
-* FiQCI: Support attaching `PROJECT_ID` environment variable content to circuit metadata.
+* FiQCI: Support attaching `PROJECT_ID` and `SLURM_JOB_ID` environment variable content to circuit metadata.
 
 Version 16.0
 ============

--- a/src/iqm/iqm_client/iqm_client.py
+++ b/src/iqm/iqm_client/iqm_client.py
@@ -502,8 +502,11 @@ def update_batch_circuit_metadata(circuit_metadata, circuits):
         new list of circuits with updated metadata
     """
 
-    for k, v in circuit_metadata.items():
-        for circuit in circuits:
+    for circuit in circuits:
+        if not hasattr(circuit, 'metadata') or circuit.metadata is None:
+            circuit.metadata = {}
+
+        for k, v in circuit_metadata.items():
             circuit.metadata[k] = v
 
     return circuits
@@ -737,15 +740,12 @@ class IQMClient:
         self._validate_circuit_instructions(architecture, circuits, qubit_mapping)
 
         # Metadata to attach to circuits
-        additional_metadata = {
-            'project_id': self._project_id,
-            'slurm_job_id': self._slurm_job_id
-        }
+        additional_metadata = {'project_id': self._project_id, 'slurm_job_id': self._slurm_job_id}
         # Filter the metadata
-        additional_metadata = {k: v for k,v in additional_metadata.items()  if v is not None}
+        additional_metadata = {k: v for k, v in additional_metadata.items() if v is not None}
         # Attach metadata to circuits metadata
         circuits = update_batch_circuit_metadata(additional_metadata, circuits)
-        
+
         # ``bearer_token`` can be ``None`` if cocos we're connecting does not use authentication
         bearer_token = self._get_bearer_token()
 

--- a/tests/test_fiqci.py
+++ b/tests/test_fiqci.py
@@ -30,6 +30,7 @@ def test_iqm_client_initializes_with_project_id(base_url):
     del os.environ['PROJECT_ID']
     assert sample_client._project_id == 'ABC123'
 
+
 def test_iqm_client_initializes_with_project_id_and_job_id(base_url):
     """Test that IQMClient initializes successfully when project/job ID is available as environment variable."""
     os.environ['PROJECT_ID'] = 'ABC123'
@@ -40,6 +41,7 @@ def test_iqm_client_initializes_with_project_id_and_job_id(base_url):
     assert sample_client._project_id == 'ABC123'
     assert sample_client._slurm_job_id == 'DEF456'
 
+
 def test_update_batch_circuit_metadata(sample_circuit):
     """Test updating batch circuit metadata."""
     metadata = {'project_id': 'ABC123'}
@@ -48,7 +50,13 @@ def test_update_batch_circuit_metadata(sample_circuit):
 
 
 def test_submit_circuits_attaches_slurm_job_id(
-    sample_client, jobs_url, minimal_run_request, submit_success, quantum_architecture_url, quantum_architecture_success, base_url
+    sample_client,
+    jobs_url,
+    minimal_run_request,
+    submit_success,
+    quantum_architecture_url,
+    quantum_architecture_success,
+    base_url,
 ):
     """
     Test submitting run request without heralding
@@ -57,18 +65,19 @@ def test_submit_circuits_attaches_slurm_job_id(
     os.environ['SLURM_JOB_ID'] = 'ABC123'
     sample_client = IQMClient(base_url)
     del os.environ['SLURM_JOB_ID']
-    
+
     # Add job_id to the metadata of the first circuit
     minimal_run_request_serialized = post_jobs_args(minimal_run_request)
-    minimal_run_request_serialized['json']['circuits'][0]['metadata']['job_id'] = 'ABC123'
-    
+
+    minimal_run_request_serialized['json']['circuits'][0]['metadata']['slurm_job_id'] = 'ABC123'
+
     # Set up mock responses
     expect(requests, times=1).post(jobs_url, **minimal_run_request_serialized).thenReturn(submit_success)
     when(requests).get(quantum_architecture_url, ...).thenReturn(quantum_architecture_success)
-    
+
     # Test .submit_circuits()
     sample_client.submit_circuits(circuits=minimal_run_request.circuits, shots=minimal_run_request.shots)
-        
+
     # Verify no unwanted interactions
     verifyNoUnwantedInteractions()
     unstub()


### PR DESCRIPTION
Changes:

1. add check for circuit.metadata attribute before performing item assignment
2. update tests to check for project_id & slurm_job_id
3. update changelog

The first change was necessary because Cirq-iqm fails at the point of adding the additional metadata to the circuit.metadata. This could be because the circuit.metadata attribute is set to None by default in cirq-iqm or it is not present (less probable but may be worth checking).